### PR TITLE
Update docs to advise manually-created collections

### DIFF
--- a/docs/divide-a-design-history-into-sections.md
+++ b/docs/divide-a-design-history-into-sections.md
@@ -17,16 +17,25 @@ You can group posts together into sections using folders:
 
 3. This is a [directory data file](https://www.11ty.dev/docs/data-template-dir/), and it can be used to set the default values for all posts that sit within this folder.
 
-4. In this JSON file, declare a tag which should be used to group these related posts, and a parent name to use in the breadcrumb navigation (the parent being the name of this section). For example
+4. In this JSON file, declare a the parent to use in the breadcrumb navigation (the parent being the name of this section). For example
 
    ```json
    {
-     "tags": ["support-interface"],
      "eleventyNavigation": {
        "parent": "Service support interface"
      }
    }
    ```
+   
+## Create a collection for each section
+
+Next, in the `eleventy.config.js` config file, add some code to add all the posts within the service folder to a named collection. Copy and paste the following lines for each folder you need to add, changing `support-interface` to whatever the folder is named.
+
+```js
+  eleventyConfig.addCollection('support-interface', collection => {
+    return collection.getFilteredByGlob('app/posts/support-interface/*.md')
+  })
+```
 
 ## Create an index page for each section
 
@@ -53,7 +62,7 @@ Next, create a page that lists these related posts. You can do that by creating 
 
    {% endraw %}
 
-   The value for `pagination.data` should use the collection created by the tag you added to the JSON file for the section. This tells the index page which posts to list. For example, if your tag is `support-interface`, the value for `pagination.data` would be `collections.support-interface`.
+   The value for `pagination.data` should use the collection created by the code you added to the `eleventy.config.js` file for the section. This tells the index page which posts to list. For example, if your collection is named `support-interface`, the value for `pagination.data` would be `collections.support-interface`.
 
    You do not need to add any body content, but if you do, this will appear above the list of posts in this section.
 
@@ -66,8 +75,6 @@ Currently the homepage lists all posts on the site. Change it so that only secti
      data: collections.post
      reverse: true
      size: 50
-   posts:
-     title: Getting started
    ```
 
 You can change the content of the heading on the homepage by adding these lines to `app/index.md`:

--- a/docs/divide-a-design-history-into-sections.md
+++ b/docs/divide-a-design-history-into-sections.md
@@ -29,7 +29,9 @@ You can group posts together into sections using folders:
    
 ## Create a collection for each section
 
-Next, in the `eleventy.config.js` config file, add some code to add all the posts within the service folder to a named collection. Copy and paste the following lines for each folder you need to add, changing `support-interface` to whatever the folder is named.
+Next, in the `eleventy.config.js` configuration file, use Eleventy’s [`addCollection` method](https://www.11ty.dev/docs/collections/#advanced-custom-filtering-and-sorting) to collect all Markdown files within the folder you created for your section.
+
+For example, to create a collection named `support-interface` that looks for posts in the `app/posts/support-interface` folder, add the following:
 
 ```js
   eleventyConfig.addCollection('support-interface', collection => {
@@ -62,7 +64,9 @@ Next, create a page that lists these related posts. You can do that by creating 
 
    {% endraw %}
 
-   The value for `pagination.data` should use the collection created by the code you added to the `eleventy.config.js` file for the section. This tells the index page which posts to list. For example, if your collection is named `support-interface`, the value for `pagination.data` would be `collections.support-interface`.
+   The value for `pagination.data` should use the same name as that used for the collection in the `eleventy.config.js` configuration file. This tells the index page which posts to list.
+   
+   For example, if your collection is named `support-interface`, the value for `pagination.data` would be `collections.support-interface`.
 
    You do not need to add any body content, but if you do, this will appear above the list of posts in this section.
 


### PR DESCRIPTION
This updates the documentation for splitting a design history into section to advise people to use manually-created collections using some code in the config file.

The advantage of using this over tags is that it means the tags don't appear within the index pages or on post pages.

Fixes https://github.com/x-govuk/govuk-eleventy-plugin/issues/157

I also did this today for the CPD design history here: https://github.com/DFE-Digital/teacher-cpd-design-history/pull/220